### PR TITLE
커뮤니티 상세보기,전체보기, 이미지 생성 삭제 구현완료

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 /build/
 !gradle/wrapper/gradle-wrapper.jar
 
+
+aws.properties
 ### STS ###
 .apt_generated
 .classpath

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,6 @@ branches:
   only:
   - master
 
-cache:
-  directories:
-  - '$HOME/.m2/repository'
-  - '$HOME/.gradle'
-
 script: "./gradlew clean build"
 
 before_deploy:

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ sourceCompatibility = 1.8
 
 repositories {
 	mavenCentral()
+	maven { url 'https://repo.spring.io/libs-milestone'}
 }
 
 
@@ -31,11 +32,17 @@ dependencies {
 	compile('org.springframework.boot:spring-boot-starter-security')
 	compile('org.springframework.boot:spring-boot-starter-web')
 	runtime('org.springframework.boot:spring-boot-devtools')
-	runtime('com.h2database:h2')
-	compile('com.auth0:java-jwt:3.3.0')
 	compile('org.springframework.cloud:spring-cloud-starter-aws')
 
+	runtime('com.h2database:h2')
+	compile('com.auth0:java-jwt:3.3.0')
 	compileOnly('org.projectlombok:lombok')
 	testCompile('org.springframework.boot:spring-boot-starter-test')
 	testCompile('org.springframework.security:spring-security-test')
+}
+
+dependencyManagement {
+	imports {
+		mavenBom 'org.springframework.cloud:spring-cloud-aws:2.0.0.RC2'
+	}
 }

--- a/src/main/java/com/walkd/dmzing/DmzingApplication.java
+++ b/src/main/java/com/walkd/dmzing/DmzingApplication.java
@@ -2,12 +2,22 @@ package com.walkd.dmzing;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @SpringBootApplication
 public class DmzingApplication {
+
+
+    public static final String APPLICATION_LOCATIONS = "spring.config.location="
+            + "classpath:application.properties,"
+            + "classpath:aws.properties";
+
+
     public static void main(String[] args) {
-        SpringApplication.run(DmzingApplication.class, args);
+        new SpringApplicationBuilder(DmzingApplication.class)
+                .properties(APPLICATION_LOCATIONS)
+                .run(args);
     }
 }

--- a/src/main/java/com/walkd/dmzing/advice/ReviewExceptionControllerAdvice.java
+++ b/src/main/java/com/walkd/dmzing/advice/ReviewExceptionControllerAdvice.java
@@ -1,0 +1,19 @@
+package com.walkd.dmzing.advice;
+
+import com.walkd.dmzing.exception.NotFoundReviewException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class ReviewExceptionControllerAdvice {
+
+    @ExceptionHandler(NotFoundReviewException.class)
+    public ResponseEntity notFoundReviewException(NotFoundReviewException exception) {
+        log.debug("[NotFoundReviewException] {}", exception.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exception.getMessage());
+    }
+}

--- a/src/main/java/com/walkd/dmzing/advice/S3ExceptionControllerAdvice.java
+++ b/src/main/java/com/walkd/dmzing/advice/S3ExceptionControllerAdvice.java
@@ -1,0 +1,26 @@
+package com.walkd.dmzing.advice;
+
+import com.walkd.dmzing.exception.AlreadySaveImageException;
+import com.walkd.dmzing.exception.BadImageUrlException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class S3ExceptionControllerAdvice {
+
+    @ExceptionHandler(AlreadySaveImageException.class)
+    public ResponseEntity alreadySaveImageException(AlreadySaveImageException exception) {
+        log.debug("[AlreadySaveImageException] {}", exception.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exception.getMessage());
+    }
+
+    @ExceptionHandler(BadImageUrlException.class)
+    public ResponseEntity badImageUrlException(BadImageUrlException exception) {
+        log.debug("[BadImageUrlException] {}", exception.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exception.getMessage());
+    }
+}

--- a/src/main/java/com/walkd/dmzing/advice/UserExceptionControllerAdvice.java
+++ b/src/main/java/com/walkd/dmzing/advice/UserExceptionControllerAdvice.java
@@ -19,8 +19,8 @@ public class UserExceptionControllerAdvice {
     }
 
     @ExceptionHandler(NotFoundUserException.class)
-    public ResponseEntity notFoundUser(NotFoundUserException exception){
-        log.debug("[NotFoundUserException] {}",exception.getMessage());
+    public ResponseEntity notFoundUser(NotFoundUserException exception) {
+        log.debug("[NotFoundUserException] {}", exception.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exception.getMessage());
     }
 }

--- a/src/main/java/com/walkd/dmzing/controller/ReviewController.java
+++ b/src/main/java/com/walkd/dmzing/controller/ReviewController.java
@@ -1,6 +1,7 @@
 package com.walkd.dmzing.controller;
 
 import com.walkd.dmzing.dto.review.ReviewDto;
+import com.walkd.dmzing.dto.review.SimpleReviewDto;
 import com.walkd.dmzing.service.ReviewService;
 import io.swagger.annotations.*;
 import lombok.extern.slf4j.Slf4j;
@@ -8,11 +9,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import springfox.documentation.annotations.ApiIgnore;
+
+import java.io.IOException;
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -25,7 +27,7 @@ public class ReviewController {
     @ApiOperation(value = "리뷰작성", notes = "리뷰에 날짜별 글을 작성 후 저장합니다.")
     @ApiResponses(value = {
             @ApiResponse(code = 201, message = "작성 성공"),
-            @ApiResponse(code = 401, message = "권한 없읍"),
+            @ApiResponse(code = 401, message = "권한 없음"),
             @ApiResponse(code = 500, message = "서버 에러")
     })
     @ApiImplicitParams({
@@ -36,4 +38,63 @@ public class ReviewController {
         reviewService.createReview(reviewDto, authentication.getPrincipal().toString());
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
+
+    @ApiOperation(value = "리뷰 이미지 등록", notes = "썸네일 이미지 및 후기 이미지를 등록합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 201, message = "저장 성공"),
+            @ApiResponse(code = 401, message = "권한 없음"),
+            @ApiResponse(code = 500, message = "서버 에러")
+    })
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "jwt", value = "JWT Token", required = true, dataType = "string", paramType = "header")
+    })
+    @PostMapping("/images")
+    public ResponseEntity<String> uploadImage(@RequestParam("data") MultipartFile multipartFile) throws IOException {
+        return ResponseEntity.status(HttpStatus.CREATED).body(reviewService.uploadImg(multipartFile));
+    }
+
+    @ApiOperation(value = "이미지 삭제", notes = "s3에 들어있는 이미지를 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "삭제 성공"),
+            @ApiResponse(code = 401, message = "권한 없음"),
+            @ApiResponse(code = 500, message = "서버 에러")
+    })
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "jwt", value = "JWT Token", required = true, dataType = "string", paramType = "header")
+    })
+    @DeleteMapping("/images")
+    public ResponseEntity<Void> removeImage(@RequestParam("imageUrl") String imageUrl) {
+        reviewService.removeImage(imageUrl);
+        return ResponseEntity.ok().build();
+    }
+
+    @ApiOperation(value = "리뷰 전체보기", notes = "리뷰를 최신순으로 30개씩 보여줍니다. * 마지막 인덱스를 넣어서 보내야합니다. 없을시 0을 넣어서 보냅니다.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "호출 성공"),
+            @ApiResponse(code = 401, message = "권한 없음"),
+            @ApiResponse(code = 500, message = "서버 에러")
+    })
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "jwt", value = "JWT Token", required = true, dataType = "string", paramType = "header")
+    })
+    @GetMapping("/last/{rid}")
+    public ResponseEntity<List<SimpleReviewDto>> showReviews(@PathVariable Long rid) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(reviewService.showReviews(rid));
+    }
+
+
+    @ApiOperation(value = "리뷰 상세보기", notes = "보고 싶은 리뷰 id를 보내면 리뷰에 상세한 내용을 볼 수 있습니다.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "호출 성공"),
+            @ApiResponse(code = 401, message = "권한 없음"),
+            @ApiResponse(code = 500, message = "서버 에러")
+    })
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "jwt", value = "JWT Token", required = true, dataType = "string", paramType = "header")
+    })
+    @GetMapping("/{rid}")
+    public ResponseEntity<SimpleReviewDto> showReview(@PathVariable Long rid) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(reviewService.showReview(rid));
+    }
+
 }

--- a/src/main/java/com/walkd/dmzing/controller/UserController.java
+++ b/src/main/java/com/walkd/dmzing/controller/UserController.java
@@ -51,7 +51,7 @@ public class UserController {
             @ApiResponse(code = 500, message = "서버 에러")
     })
     @PostMapping("/login")
-    public void login(@Validated(LoginUser.class) @RequestBody UserDto userDto) {
+    public void login(@Validated(LoginUser.class) @RequestBody LoginUser loginUser) {
     }
 
 }

--- a/src/main/java/com/walkd/dmzing/domain/BaseTimeEntity.java
+++ b/src/main/java/com/walkd/dmzing/domain/BaseTimeEntity.java
@@ -22,8 +22,8 @@ public abstract class BaseTimeEntity {
     @CreatedDate
     private Date createdAt;
 
-    public static Date nowToDate() {
-        return Date.from(LocalDateTime.now().toInstant(ZoneOffset.ofHours(9)));
+    public static Long nowToDate() {
+        return Date.from(LocalDateTime.now().toInstant(ZoneOffset.ofHours(9))).getTime();
     }
 
     public static Date nowAfterDaysToDate(Long days) {

--- a/src/main/java/com/walkd/dmzing/domain/Course.java
+++ b/src/main/java/com/walkd/dmzing/domain/Course.java
@@ -1,10 +1,13 @@
 package com.walkd.dmzing.domain;
 
+import lombok.Getter;
+
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
+@Getter
 @Entity
 public class Course {
 

--- a/src/main/java/com/walkd/dmzing/domain/Post.java
+++ b/src/main/java/com/walkd/dmzing/domain/Post.java
@@ -1,11 +1,16 @@
 package com.walkd.dmzing.domain;
 
+import com.walkd.dmzing.dto.review.PostDto;
+import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,5 +29,14 @@ public class Post extends BaseTimeEntity {
         this.title = title;
         this.content = content;
         this.postImgs = postImgs;
+    }
+
+    public PostDto toDto() {
+        return PostDto.builder()
+                .day(day)
+                .content(content)
+                .title(title)
+                .postImgUrl(postImgs.stream().map(postImg -> postImg.getImgUrl()).collect(Collectors.toList()))
+                .build();
     }
 }

--- a/src/main/java/com/walkd/dmzing/domain/PostImg.java
+++ b/src/main/java/com/walkd/dmzing/domain/PostImg.java
@@ -1,11 +1,17 @@
 package com.walkd.dmzing.domain;
 
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
+@Getter
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PostImg {
 
     @Id
@@ -18,3 +24,4 @@ public class PostImg {
         this.imgUrl = imgUrl;
     }
 }
+

--- a/src/main/java/com/walkd/dmzing/domain/Review.java
+++ b/src/main/java/com/walkd/dmzing/domain/Review.java
@@ -1,12 +1,18 @@
 package com.walkd.dmzing.domain;
 
 
+import com.walkd.dmzing.dto.review.ReviewDto;
+import com.walkd.dmzing.dto.review.SimpleReviewDto;
+import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Review extends BaseTimeEntity {
 
     @Id
@@ -36,14 +42,34 @@ public class Review extends BaseTimeEntity {
         this.thumbnailUrl = thumbnailUrl;
     }
 
-    public Review setUser(User user){
+    public Review setUser(User user) {
         this.user = user;
         return this;
     }
 
-    public Review setCourse(Course course){
+    public Review setCourse(Course course) {
         this.course = course;
         return this;
     }
 
+    public SimpleReviewDto toSimpleDto() {
+        return ReviewDto.builder()
+                .id(id)
+                .title(title)
+                .createdAt(getCreatedAt().getTime())
+                .thumbnailUrl(thumbnailUrl)
+                .courseId(course.getId())
+                .build();
+    }
+
+    public ReviewDto toDto() {
+        return ReviewDto.builder()
+                .id(id)
+                .title(title)
+                .createdAt(getCreatedAt().getTime())
+                .thumbnailUrl(thumbnailUrl)
+                .courseId(course.getId())
+                .postDto(posts.stream().map(post -> post.toDto()).collect(Collectors.toList()))
+                .build();
+    }
 }

--- a/src/main/java/com/walkd/dmzing/dto/review/PostDto.java
+++ b/src/main/java/com/walkd/dmzing/dto/review/PostDto.java
@@ -3,6 +3,8 @@ package com.walkd.dmzing.dto.review;
 import com.walkd.dmzing.domain.Post;
 import com.walkd.dmzing.domain.PostImg;
 import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,7 +12,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Getter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class PostDto {
     @ApiModelProperty(example = "1", position = 1)
     private Long day;

--- a/src/main/java/com/walkd/dmzing/dto/review/ReviewDto.java
+++ b/src/main/java/com/walkd/dmzing/dto/review/ReviewDto.java
@@ -1,16 +1,22 @@
 package com.walkd.dmzing.dto.review;
 
 import com.walkd.dmzing.domain.Review;
-import com.walkd.dmzing.domain.User;
 import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Getter
+@Builder
 @NoArgsConstructor
-public class ReviewDto {
+@AllArgsConstructor
+public class ReviewDto implements SimpleReviewDto {
+    //todo id는 삽입할때 빼도록 적용
+    private Long id;
 
     @ApiModelProperty(example = "dmzing 후기", position = 1)
     private String title;
@@ -20,6 +26,8 @@ public class ReviewDto {
 
     @ApiModelProperty(example = "1", position = 3)
     private Long courseId;
+
+    private Long createdAt;
 
     private List<PostDto> postDto;
 

--- a/src/main/java/com/walkd/dmzing/dto/review/SimpleReviewDto.java
+++ b/src/main/java/com/walkd/dmzing/dto/review/SimpleReviewDto.java
@@ -1,0 +1,21 @@
+package com.walkd.dmzing.dto.review;
+
+import io.swagger.annotations.ApiModelProperty;
+
+public interface SimpleReviewDto {
+    //todo 직렬화시 여기 getter만 나가도록 적용
+    @ApiModelProperty(example = "1", position = 1)
+    Long getId();
+
+    @ApiModelProperty(example = "dmzing 후기", position = 2)
+    String getTitle();
+
+    @ApiModelProperty(example = "dmzing.png", position = 3)
+    String getThumbnailUrl();
+
+    @ApiModelProperty(example = "15203333", position = 4)
+    Long getCreatedAt();
+
+    @ApiModelProperty(example = "1", position = 5)
+    Long getCourseId();
+}

--- a/src/main/java/com/walkd/dmzing/dto/user/JoinUser.java
+++ b/src/main/java/com/walkd/dmzing/dto/user/JoinUser.java
@@ -1,4 +1,5 @@
 package com.walkd.dmzing.dto.user;
+
 //todo 조인유저 제거
 public interface JoinUser {
 }

--- a/src/main/java/com/walkd/dmzing/dto/user/LoginUser.java
+++ b/src/main/java/com/walkd/dmzing/dto/user/LoginUser.java
@@ -1,5 +1,11 @@
 package com.walkd.dmzing.dto.user;
 
-public interface LoginUser {
+import io.swagger.annotations.ApiModelProperty;
 
+public interface LoginUser {
+    @ApiModelProperty(example = "example@gmail.com", position = 1)
+    String getEmail();
+
+    @ApiModelProperty(example = "qwer1234@@", position = 2)
+    String getPassword();
 }

--- a/src/main/java/com/walkd/dmzing/dto/user/UserDto.java
+++ b/src/main/java/com/walkd/dmzing/dto/user/UserDto.java
@@ -14,7 +14,7 @@ import javax.validation.constraints.Size;
 @Getter
 @NoArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class UserDto {
+public class UserDto implements LoginUser {
     private final static String EMAIL_REGEX = "^[_0-9a-zA-Z-]+@[0-9a-zA-Z]+[.[_0-9a-zA-Z-]+]*$";
     private final static String PASSWORD_REGEX = "^(?=.*?[a-zA-Z])(?=.*?[0-9]).{8,12}$";
     private final static String PHONE_NO_REGEX = "^01[0|1|6-9]-[0-9]{3,4}-[0-9]{4}$";

--- a/src/main/java/com/walkd/dmzing/exception/AlreadySaveImageException.java
+++ b/src/main/java/com/walkd/dmzing/exception/AlreadySaveImageException.java
@@ -1,0 +1,7 @@
+package com.walkd.dmzing.exception;
+
+public class AlreadySaveImageException extends RuntimeException {
+    public AlreadySaveImageException() {
+        super("이미 db에 저장된 이미지입니다.");
+    }
+}

--- a/src/main/java/com/walkd/dmzing/exception/BadImageUrlException.java
+++ b/src/main/java/com/walkd/dmzing/exception/BadImageUrlException.java
@@ -1,0 +1,7 @@
+package com.walkd.dmzing.exception;
+
+public class BadImageUrlException extends RuntimeException {
+    public BadImageUrlException() {
+        super("잘못된 이미지 경로입니다.");
+    }
+}

--- a/src/main/java/com/walkd/dmzing/exception/NotFoundCourseException.java
+++ b/src/main/java/com/walkd/dmzing/exception/NotFoundCourseException.java
@@ -1,7 +1,7 @@
 package com.walkd.dmzing.exception;
 
 public class NotFoundCourseException extends RuntimeException {
-    public NotFoundCourseException(){
+    public NotFoundCourseException() {
         super("코스를 찾을 수 없습니다.");
     }
 }

--- a/src/main/java/com/walkd/dmzing/exception/NotFoundReviewException.java
+++ b/src/main/java/com/walkd/dmzing/exception/NotFoundReviewException.java
@@ -1,0 +1,7 @@
+package com.walkd.dmzing.exception;
+
+public class NotFoundReviewException extends RuntimeException {
+    public NotFoundReviewException() {
+        super("해당 리뷰가 없습니다.");
+    }
+}

--- a/src/main/java/com/walkd/dmzing/exception/NotFoundUserException.java
+++ b/src/main/java/com/walkd/dmzing/exception/NotFoundUserException.java
@@ -1,7 +1,7 @@
 package com.walkd.dmzing.exception;
 
 public class NotFoundUserException extends RuntimeException {
-    public NotFoundUserException(){
+    public NotFoundUserException() {
         super("유저를 찾을 수 없습니다.");
     }
 }

--- a/src/main/java/com/walkd/dmzing/repository/PostImgRepository.java
+++ b/src/main/java/com/walkd/dmzing/repository/PostImgRepository.java
@@ -4,4 +4,5 @@ import com.walkd.dmzing.domain.PostImg;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostImgRepository extends JpaRepository<PostImg, Long> {
+    boolean existsByImgUrl(String imgUrl);
 }

--- a/src/main/java/com/walkd/dmzing/repository/ReviewRepository.java
+++ b/src/main/java/com/walkd/dmzing/repository/ReviewRepository.java
@@ -3,5 +3,13 @@ package com.walkd.dmzing.repository;
 import com.walkd.dmzing.domain.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    List<Review> findTop30ByIdLessThanOrderByIdDesc(Long id);
+
+    List<Review> findTop30ByOrderByIdDesc();
+
+    boolean existsByThumbnailUrl(String imageUrl);
 }

--- a/src/main/java/com/walkd/dmzing/service/ReviewService.java
+++ b/src/main/java/com/walkd/dmzing/service/ReviewService.java
@@ -3,15 +3,27 @@ package com.walkd.dmzing.service;
 import com.walkd.dmzing.domain.Course;
 import com.walkd.dmzing.domain.User;
 import com.walkd.dmzing.dto.review.ReviewDto;
+import com.walkd.dmzing.dto.review.SimpleReviewDto;
+import com.walkd.dmzing.exception.AlreadySaveImageException;
+import com.walkd.dmzing.exception.BadImageUrlException;
 import com.walkd.dmzing.exception.NotFoundCourseException;
 import com.walkd.dmzing.exception.NotFoundUserException;
 import com.walkd.dmzing.repository.*;
+import com.walkd.dmzing.util.S3Util;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.transaction.Transactional;
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
 
+@Slf4j
 @Service
+@RequiredArgsConstructor
 public class ReviewService {
 
     @Autowired
@@ -23,12 +35,52 @@ public class ReviewService {
     @Autowired
     private CourseRepository courseRepository;
 
+    @Autowired
+    private PostImgRepository postImgRepository;
+
+    private final S3Util s3Util;
+
+
     @Transactional
-    public void createReview(ReviewDto reviewDto,String email) {
+    public void createReview(ReviewDto reviewDto, String email) {
         User user = userRepository.findByEmail(email).orElseThrow(NotFoundUserException::new);
         Course course = courseRepository.findById(reviewDto.getCourseId()).orElseThrow(NotFoundCourseException::new);
 
         reviewRepository.save(reviewDto.toEntity().setUser(user).setCourse(course));
     }
 
+    public List<SimpleReviewDto> showReviews(Long id) {
+        if (id == 0) {
+            return reviewRepository.findTop30ByOrderByIdDesc()
+                    .stream()
+                    .map(review -> review.toSimpleDto())
+                    .collect(Collectors.toList());
+        }
+        return reviewRepository.findTop30ByIdLessThanOrderByIdDesc(id)
+                .stream()
+                .map(review -> review.toSimpleDto())
+                .collect(Collectors.toList());
+    }
+
+    public void removeImage(String imageUrl) {
+        if (!reviewRepository.existsByThumbnailUrl(imageUrl) && !postImgRepository.existsByImgUrl(imageUrl)) {
+            try {
+                s3Util.removeFileFromS3(new StringBuilder()
+                        .append(S3Util.REVIEW_DIR)
+                        .append(imageUrl.substring(imageUrl.lastIndexOf("/"))).toString());
+                return;
+            } catch (StringIndexOutOfBoundsException e) {
+                throw new BadImageUrlException();
+            }
+        }
+        throw new AlreadySaveImageException();
+    }
+
+    public String uploadImg(MultipartFile multipartFile) throws IOException {
+        return s3Util.upload(multipartFile, s3Util.REVIEW_DIR);
+    }
+
+    public ReviewDto showReview(Long rid) {
+        return reviewRepository.findById(rid).orElseThrow(NotFoundCourseException::new).toDto();
+    }
 }

--- a/src/main/java/com/walkd/dmzing/util/S3Util.java
+++ b/src/main/java/com/walkd/dmzing/util/S3Util.java
@@ -1,0 +1,76 @@
+package com.walkd.dmzing.util;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.walkd.dmzing.domain.BaseTimeEntity;
+import lombok.RequiredArgsConstructor;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Optional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class S3Util {
+    public static final String REVIEW_DIR = "review";
+
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String upload(MultipartFile multipartFile, String dirName) throws IOException {
+        File uploadFile = convert(multipartFile)
+                .orElseThrow(() -> new IllegalArgumentException("MultipartFile -> File로 전환이 실패했습니다."));
+
+        return upload(uploadFile, dirName);
+    }
+
+    private String upload(File uploadFile, String dirName) {
+        String fileName = new StringBuilder().append(dirName)
+                .append("/").append(BaseTimeEntity.nowToDate())
+                .append("_").append(uploadFile.getName()).toString();
+        String uploadImageUrl = putS3(uploadFile, fileName);
+        removeNewFile(uploadFile);
+        return uploadImageUrl;
+    }
+
+    private String putS3(File uploadFile, String fileName) {
+        amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, uploadFile).withCannedAcl(CannedAccessControlList.PublicRead));
+        return amazonS3Client.getUrl(bucket, fileName).toString();
+    }
+
+    private void removeNewFile(File targetFile) {
+        if (targetFile.delete()) {
+            log.info("파일이 삭제되었습니다.");
+
+        } else {
+            log.info("파일이 삭제되지 못했습니다.");
+        }
+    }
+
+    private Optional<File> convert(MultipartFile file) throws IOException {
+        File convertFile = new File(file.getOriginalFilename());
+        if (convertFile.createNewFile()) {
+            try (FileOutputStream fos = new FileOutputStream(convertFile)) {
+                fos.write(file.getBytes());
+            }
+            return Optional.of(convertFile);
+        }
+
+        return Optional.empty();
+    }
+
+    public void removeFileFromS3(String key) {
+        amazonS3Client.deleteObject(bucket, key);
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,7 @@ spring.jpa.show-sql=true
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.properties.hibernate.format_sql=true
 spring.h2.console.enabled=true
+cloud.aws.s3.bucket=dmzing-s3
+cloud.aws.region.static=ap-northeast-2
+spring.servlet.multipart.max-file-size:10MB
+spring.servlet.multipart.max-request-size:10MB

--- a/src/main/resources/aws.properties
+++ b/src/main/resources/aws.properties
@@ -1,0 +1,2 @@
+cloud.aws.credentials.accessKey = AKIAJPP2BUV4UXJANM4A
+cloud.aws.credentials.secretKey = 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


### PR DESCRIPTION
1. 커뮤니티 전체보기를 구현하였습니다.
	-0을 넣으면 최신 30개를 불러옵니다.
	-마지막 인덱스를 넣으면 그 다음 30개를 불러옵니다.
2. 커뮤니티 상세보기를 구현하였습니다.
	-리뷰 인덱스를 넣으면 상세한 정보를 반환합니다.
3. 이미지 생성삭제를 구현하였습니다.
	-이미지를 넣어서 보내면 이미지 url을 반환합니다.
	-이미지 url를 보내면 이미지를 삭제합니다.